### PR TITLE
MM-339: Add highway:busway into service-class mapping

### DIFF
--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -230,6 +230,7 @@ tables:
       - track
       - raceway
       - construction
+      - busway
       public_transport:
       - platform
       man_made:

--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -40,7 +40,7 @@ layer:
           highway: ['pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor']
           public_transport: 'platform'
         service:
-          highway: service
+          highway: ['service', 'busway']
         track:
           highway: track
         raceway:


### PR DESCRIPTION
Before this change, highway that were attributed as highway: busway didn't get mapped at all. These changes map that into the same class highway: service allowing them to be visible on our data.