### PR TITLE
MM-28: Filter unnecessary housenumbers

### DIFF
--- a/layers/housenumber/housenumber.sql
+++ b/layers/housenumber/housenumber.sql
@@ -6,7 +6,10 @@ CREATE OR REPLACE FUNCTION layer_housenumber(bbox geometry, zoom_level integer)
             (
                 osm_id      bigint,
                 geometry    geometry,
-                housenumber text
+                housenumber text,
+                unit        text,
+                ref         text,
+                entrance    text
             )
 AS
 $$
@@ -14,7 +17,10 @@ SELECT
     -- etldoc: osm_housenumber_point -> layer_housenumber:z14_
     osm_id,
     geometry,
-    housenumber
+    housenumber,
+    unit,
+    ref,
+    entrance
 FROM osm_housenumber_point
 WHERE zoom_level >= 14
   AND geometry && bbox;

--- a/layers/housenumber/housenumber.yaml
+++ b/layers/housenumber/housenumber.yaml
@@ -7,10 +7,13 @@ layer:
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     housenumber: Value of the [`addr:housenumber`](http://wiki.openstreetmap.org/wiki/Key:addr) tag.
+    unit: Unit number 
+    ref: Other tag that might contain the unit number in some instances
+    entrance: Entrance number
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, housenumber FROM layer_housenumber(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, housenumber, unit, ref, entrance FROM layer_housenumber(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./housenumber_centroid.sql
   - ./housenumber.sql

--- a/layers/housenumber/mapping.yaml
+++ b/layers/housenumber/mapping.yaml
@@ -4,7 +4,7 @@ tables:
   # etldoc: imposm3 -> osm_housenumber_point
   housenumber_point:
     type: geometry
-    filters: 
+    filters:
       reject:
         building: ['no', none]
         office: [__any__]
@@ -18,6 +18,18 @@ tables:
       type: geometry
     - name: housenumber
       key: addr:housenumber
+      type: string
+    - name: office
+      key: office
+      type: string
+    - name: shop
+      key: shop
+      type: string
+    - name: leisure
+      key: leisure
+      type: string
+    - name: amenity
+      key: amenity
       type: string
     type_mappings:
       points:

--- a/layers/housenumber/mapping.yaml
+++ b/layers/housenumber/mapping.yaml
@@ -20,6 +20,15 @@ tables:
     - name: housenumber
       key: addr:housenumber
       type: string
+    - name: unit
+      key: addr:unit
+      type: string
+    - name: ref
+      key: ref
+      type: string
+    - name: entrance
+      key: entrance
+      type: string
     - name: office
       key: office
       type: string

--- a/layers/housenumber/mapping.yaml
+++ b/layers/housenumber/mapping.yaml
@@ -4,6 +4,13 @@ tables:
   # etldoc: imposm3 -> osm_housenumber_point
   housenumber_point:
     type: geometry
+    filters: 
+      reject:
+        building: ['no', none]
+        office: [__any__]
+        shop: [__any__]
+        leisure: [__any__]
+        amenity: [__any__]
     columns:
     - name: osm_id
       type: id

--- a/layers/housenumber/mapping.yaml
+++ b/layers/housenumber/mapping.yaml
@@ -11,6 +11,7 @@ tables:
         shop: [__any__]
         leisure: [__any__]
         amenity: [__any__]
+        tourism: [__any__]
     columns:
     - name: osm_id
       type: id
@@ -30,6 +31,9 @@ tables:
       type: string
     - name: amenity
       key: amenity
+      type: string
+    - name: tourism
+      key: tourism
       type: string
     type_mappings:
       points:


### PR DESCRIPTION
Filtering unnecessary housenumbers from buildings and POIs inside them. There are still some weird edge cases, but most of the numbers from shopping centers/areas are gone.